### PR TITLE
added apache2 require statement

### DIFF
--- a/modules/rhizo_base/manifests/init.pp
+++ b/modules/rhizo_base/manifests/init.pp
@@ -212,6 +212,7 @@ class rhizo_base {
 
   file { '/var/www/html':
       ensure  => directory,
+      require => Package['apache2'],
     }
 
   file { '/var/rhizo_backups/postgresql':


### PR DESCRIPTION
added requirement for apache2 install before creating html directory inside var/www.
error occurs without requirement stating directory does not exist.