### PR TITLE
added postgresql requirement

### DIFF
--- a/modules/rhizo_base/manifests/init.pp
+++ b/modules/rhizo_base/manifests/init.pp
@@ -218,7 +218,7 @@ class rhizo_base {
       ensure  => directory,
       owner   => 'postgres',
       group   => 'postgres',
-      require => File['/var/rhizo_backups'],
+      require => [ File['/var/rhizo_backups'], Class['rhizo_base::postgresql'] ],
     }
 
   file { '/var/rhizo_backups/sqlite':


### PR DESCRIPTION
added rhizo_base::postgresql requirement to stop error citing " no postgres user" due to trying to create the file and assign to postgres user before postgresql is installed.