### PR TITLE
Devel concat update

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,7 @@ Same goes for freeswitch. FIXES??
 - After install and reboot, considering add the user rhizomatica to the sudo group: `usermod -aG sudo rhizomatica`
 
 - After install, you do not really need the puppet master service running, so
-consider disabling it. 
-
-- There is one persistant error from puppet, but it doesn't seem to affect us:
-```
-Error: /Stage[main]/Postgresql::Server::Config/Concat[/etc/postgresql/9.6/main/pg_hba.conf]/Concat_file[/etc/postgresql/9.6/main/pg_hba.conf]: Failed to generate additional resources using 'eval_generate': comparison of Array with Array failed
-```
-
+consider disabling it.
 
 ----------
 


### PR DESCRIPTION
The concat module has a bug that was leading to the spurious postgres failure. Updating the module to the next patch version allows for checking the success of the puppet agent run without needing to ignore a failure.

Testing:
Tested `puppet agent --test` on debian9 and hand validated that postgres and RAI were working appropriately.