### PR TITLE
rhizo_base/openbsc: Update osmocom-nitb to 1.3.0

### DIFF
--- a/modules/rhizo_base/manifests/openbsc.pp
+++ b/modules/rhizo_base/manifests/openbsc.pp
@@ -35,7 +35,7 @@ class rhizo_base::openbsc {
   $ggsn_ip_address = hiera('rhizo::ggsn_ip_address')
 
   package {  [ 'osmocom-nitb' ]:
-      ensure   => '1.2.0',
+      ensure   => '1.3.0',
       require  => Class['rhizo_base::apt'],
       notify   => [ Exec['hlr_pragma_wal'],
                     Exec['notify-nitb'] ],


### PR DESCRIPTION
A new tag has been pushed and 1.3.0 is now the version available in
the osmocom/latest repos.

http://git.osmocom.org/openbsc/tag/?h=1.3.0

Testing:
Tested ability to `puppet apply --test` on debian9 and that the nitb came up successfully. I do not have a bts setup so I did not test end to end call functionality.