### PR TITLE
rhizo_base: Add contains dependencies

### DIFF
--- a/modules/rhizo_base/manifests/apt.pp
+++ b/modules/rhizo_base/manifests/apt.pp
@@ -12,7 +12,7 @@
 #
 
 class rhizo_base::apt {
-  include "rhizo_base::apt::$operatingsystem"
+  contain "rhizo_base::apt::$operatingsystem"
 }
 
 class rhizo_base::apt::common {

--- a/modules/rhizo_base/manifests/fixes.pp
+++ b/modules/rhizo_base/manifests/fixes.pp
@@ -12,7 +12,7 @@
 #
 
 class rhizo_base::fixes {
-  include "rhizo_base::fixes::$operatingsystem"
+  contain "rhizo_base::fixes::$operatingsystem"
 
   file { '/etc/tmux.conf':
       ensure  => present,

--- a/modules/rhizo_base/manifests/freeswitch.pp
+++ b/modules/rhizo_base/manifests/freeswitch.pp
@@ -11,7 +11,7 @@
 # Sample Usage:
 #
 class rhizo_base::freeswitch {
-  include "rhizo_base::freeswitch::$operatingsystem"
+  contain "rhizo_base::freeswitch::$operatingsystem"
 }
 
 class rhizo_base::freeswitch::ubuntu inherits rhizo_base::freeswitch::common {

--- a/modules/rhizo_base/manifests/packages.pp
+++ b/modules/rhizo_base/manifests/packages.pp
@@ -11,7 +11,7 @@
 # Sample Usage:
 #
 class rhizo_base::packages {
-  include "rhizo_base::packages::$operatingsystem"
+  contain "rhizo_base::packages::$operatingsystem"
 }
 
 class rhizo_base::packages::common {

--- a/modules/rhizo_base/manifests/postgresql.pp
+++ b/modules/rhizo_base/manifests/postgresql.pp
@@ -12,7 +12,7 @@
 #
 
 class rhizo_base::postgresql {
-  include "rhizo_base::postgresql::$operatingsystem"
+  contain "rhizo_base::postgresql::$operatingsystem"
 }
 
 class rhizo_base::postgresql::common {


### PR DESCRIPTION
Puppet treats included classes specially, and does not assume that
they are contained in their outside class for the sake of dependency
ordering. This means that any other resources requiring the base
non-distribution specific classes were actually not capturing the
ordering dependencies on resources defined in the distribution
specific class!