### PR TITLE
Fix small typo

### DIFF
--- a/modules/rhizo_base/files/usr/etc/lcr/options.conf
+++ b/modules/rhizo_base/files/usr/etc/lcr/options.conf
@@ -47,7 +47,7 @@ alaw
 # bus/cpu load at all, except when the tone changes.
 # Use parameter "american", "german", or "oldgerman". "oldgerman" sounds like
 # the old german telephone system used until end of year 1998.
-# This can be overridden by the the tones_dir in the interface.conf.
+# This can be overridden by the tones_dir in the interface.conf.
 # Both options.conf and interface.conf can be overridden by extension setting.
 #tones_dir tones_american
 


### PR DESCRIPTION
`s/the the /the /g`